### PR TITLE
Allow Sponge to use Java 9

### DIFF
--- a/src/java6/java/org/spongepowered/launch/JavaVersionCheckUtils.java
+++ b/src/java6/java/org/spongepowered/launch/JavaVersionCheckUtils.java
@@ -73,6 +73,10 @@ public class JavaVersionCheckUtils {
         // Split the version up into parts
         String[] versionParts = version.split("\\.");
         double versionValue = 0;
+        // Workaround for Java 9+ version strings
+        if (versionParts.length > 0 && !versionParts[0].equals("1")) {
+            versionValue = Math.pow(10, versionParts.length * 3);
+        }
         for(int i = 0; i < versionParts.length; i++) {
             try {
                 int part = Integer.valueOf(versionParts[i]);


### PR DESCRIPTION
After Java 9, version strings do not match the 1.x.x scheme anymore.

For example: Java 8 - 1.8.0_144
Java 9 - 9
Java 9.0.1 - 9.0.1

Because of this change, Sponge thinks that Java 9 is an older version than Java 8, and terminates the server on startup. This pull request proposes a solution to this problem.